### PR TITLE
ci: add GitHub Actions workflow for Go tests and web-ui typecheck/build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,29 +1,51 @@
 name: CI
-on: [push, pull_request]
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
+
 jobs:
   server-daemon:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
-        with: { go-version: '1.22' }
-      - run: go work sync || true
-      - run: go test ./... -race -cover
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: ./server/go.mod
+      - name: Go work sync (tolerant)
+        run: go work sync || true
+      - name: Go test server (race, cover)
+        run: go test ./... -race -cover
         working-directory: server
-      - run: go test ./... -race -cover
+      - name: Go test client-daemon (race, cover)
+        run: go test ./... -race -cover
         working-directory: client-daemon
+
   web-ui:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with: { node-version: '20' }
-      - run: npm install
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: web-ui/package-lock.json
+      - name: Install deps
+        run: npm ci
         working-directory: web-ui
-      - run: npm run typecheck
+      - name: Typecheck
+        run: npm run typecheck --if-present
         working-directory: web-ui
-      - run: npm run build --if-present
+      - name: Build
+        run: npm run build --if-present
         working-directory: web-ui


### PR DESCRIPTION
- Server and client-daemon: go test ./... -race -cover
- Web UI: npm ci, typecheck, build (cached)
- Concurrency control to cancel in-progress runs per ref